### PR TITLE
fix: auto-detect installation directory for brew compatibility

### DIFF
--- a/apple-juice.sh
+++ b/apple-juice.sh
@@ -18,7 +18,14 @@ PATH=/usr/local/co.apple-juice:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/b
 ## ###############
 ## Variables
 ## ###############
-binfolder=/usr/local/co.apple-juice
+# Auto-detect installation directory (supports both curl and brew installs)
+# Resolve symlinks to get the actual script location
+script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")"
+binfolder="$(dirname "$script_path")"
+# Fall back to standard location if detection fails
+if [[ ! -x "$binfolder/smc" ]]; then
+    binfolder=/usr/local/co.apple-juice
+fi
 visudo_folder=/private/etc/sudoers.d
 visudo_file=${visudo_folder}/apple-juice
 configfolder=$HOME/.apple-juice


### PR DESCRIPTION
## Motivation

Brew-installed versions were prompting for password because the visudo was configured for `/usr/local/co.apple-juice/smc` but brew installs to `/opt/homebrew/Cellar/apple-juice/*/bin/smc`.

## Summary

- Auto-detect the script's actual location using readlink/realpath
- Use the detected directory as binfolder so visudo paths match
- Fall back to standard location if smc not found in detected directory

This is the proper fix instead of creating symlinks.

Generated with [Claude Code](https://claude.com/claude-code)