### PR TITLE
fix: create config file if missing in write_config

### DIFF
--- a/apple-juice.sh
+++ b/apple-juice.sh
@@ -1225,17 +1225,19 @@ function read_config() { # read $val of $name in config_file
 function write_config() { # write $val to $name in config_file
 	name=$1
 	val=$2
-	if test -f "$config_file"; then
-		config=$(cat "$config_file" 2>/dev/null)
-		name_loc=$(echo "$config" | grep -n "$name" | cut -d: -f1)
-		if [[ $name_loc ]]; then
-			# Escape sed special characters in both name and value
-			name_escaped=$(printf '%s\n' "$name" | sed 's/[&/\]/\\&/g')
-			val_escaped=$(printf '%s\n' "$val" | sed 's/[&/\]/\\&/g')
-			sed -i '' "${name_loc}s/.*/${name_escaped} = ${val_escaped}/" "$config_file"
-		else # not exist yet
-			echo "$name = $val" >> "$config_file"
-		fi
+	# Create config file if it doesn't exist
+	if ! test -f "$config_file"; then
+		touch "$config_file"
+	fi
+	config=$(cat "$config_file" 2>/dev/null)
+	name_loc=$(echo "$config" | grep -n "$name" | cut -d: -f1)
+	if [[ $name_loc ]]; then
+		# Escape sed special characters in both name and value
+		name_escaped=$(printf '%s\n' "$name" | sed 's/[&/\]/\\&/g')
+		val_escaped=$(printf '%s\n' "$val" | sed 's/[&/\]/\\&/g')
+		sed -i '' "${name_loc}s/.*/${name_escaped} = ${val_escaped}/" "$config_file"
+	else # not exist yet
+		echo "$name = $val" >> "$config_file"
 	fi
 }
 


### PR DESCRIPTION
## Motivation

Brew installations don't run setup.sh, so the config file at `~/.apple-juice/config` isn't created. The `write_config` function silently did nothing when the config file was missing, causing longevity mode and other settings to not persist.

## Summary

- `write_config` now creates the config file if it doesn't exist
- This ensures brew-installed versions work correctly without manual intervention

Generated with [Claude Code](https://claude.com/claude-code)