### PR TITLE
fix: suppress expected launchctl bootstrap errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,3 +129,7 @@ Safety watchdog fix and CLI cleanup. **Breaking**: six commands removed (see bel
 - Daemon initialises `isSleeping` from on-disk `sleep.state` at startup so DarkWake restarts preserve the sleeping marker instead of immediately deleting it
 - `sleep.state` deletion gated on successful PID file write and moved from `didWake` to `writePidFile()` to eliminate a race at full wake
 - Warning logs added for failed writes to sleep state, daily log, and balance subprocess launch
+
+## v3.0.5
+
+- Suppressed expected launchctl bootstrap errors from user-facing output (bootstrap fails when the service is already loaded, which is normal during KeepAlive restarts and daemon recovery)

--- a/Sources/AppleJuice/AppleJuice.swift
+++ b/Sources/AppleJuice/AppleJuice.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
 
-let appVersion = "3.0.4"
+let appVersion = "3.0.5"
 
 @main
 struct AppleJuice: ParsableCommand {

--- a/Sources/AppleJuice/Daemon/DaemonManager.swift
+++ b/Sources/AppleJuice/Daemon/DaemonManager.swift
@@ -81,10 +81,10 @@ enum DaemonManager {
         Thread.sleep(forTimeInterval: 0.5)
         launchctl("launchctl enable gui/\(uid)/com.apple-juice.app")
         if FileManager.default.fileExists(atPath: Paths.daemonPath) {
-            let result = launchctl("launchctl bootstrap gui/\(uid) '\(Paths.daemonPath)'")
+            let result = launchctl("launchctl bootstrap gui/\(uid) '\(Paths.daemonPath)'", silent: true)
             if !result.succeeded {
                 Thread.sleep(forTimeInterval: 1)
-                launchctl("launchctl bootstrap gui/\(uid) '\(Paths.daemonPath)'")
+                launchctl("launchctl bootstrap gui/\(uid) '\(Paths.daemonPath)'", silent: true)
             }
         }
         launchctl("launchctl kickstart gui/\(uid)/com.apple-juice.app")
@@ -166,10 +166,10 @@ enum DaemonManager {
         launchctl("launchctl enable gui/\(uid)/com.apple-juice.safety")
         launchctl("launchctl bootout gui/\(uid)/com.apple-juice.safety", silent: true)
         Thread.sleep(forTimeInterval: 0.5)
-        let result = launchctl("launchctl bootstrap gui/\(uid) '\(path)'")
+        let result = launchctl("launchctl bootstrap gui/\(uid) '\(path)'", silent: true)
         if !result.succeeded {
             Thread.sleep(forTimeInterval: 1)
-            launchctl("launchctl bootstrap gui/\(uid) '\(path)'")
+            launchctl("launchctl bootstrap gui/\(uid) '\(path)'", silent: true)
         }
         // No kickstart -- let StartCalendarInterval handle timing.
         // Kickstarting here races with daemon startup since createSafetyDaemon()
@@ -235,7 +235,7 @@ enum DaemonManager {
         launchctl("launchctl enable gui/\(uid)/com.apple-juice_schedule.app")
         // Bootstrap if not loaded
         if FileManager.default.fileExists(atPath: Paths.schedulePath) {
-            launchctl("launchctl bootstrap gui/\(uid) '\(Paths.schedulePath)'")
+            launchctl("launchctl bootstrap gui/\(uid) '\(Paths.schedulePath)'", silent: true)
         }
     }
 


### PR DESCRIPTION
## Motivation

Running `aj maintain longevity` prints `launchctl: Bootstrap failed: 5: Input/output error` to the user. This happens because the service is already loaded (KeepAlive restarted it), so bootstrap correctly fails -- but the error shouldn't be shown to the user.

## Summary

- All `launchctl bootstrap` calls now use `silent: true` (maintain daemon, safety watchdog, schedule daemon)
- `bootout` calls already used `silent: true` for the same reason

Generated with [Claude Code](https://claude.com/claude-code)