### PR TITLE
fix: prevent main loop from overriding willSleep charging decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,3 +133,7 @@ Safety watchdog fix and CLI cleanup. **Breaking**: six commands removed (see bel
 ## v3.0.5
 
 - Suppressed expected launchctl bootstrap errors from user-facing output (bootstrap fails when the service is already loaded, which is normal during KeepAlive restarts and daemon recovery)
+
+## v3.0.6
+
+- Main loop no longer re-enables charging when `isSleeping` is true -- the willSleep handler intentionally disabled charging, but the main loop's next iteration saw "battery below 60%" and overrode it, causing uncontrolled charging during sleep

--- a/Sources/AppleJuice/AppleJuice.swift
+++ b/Sources/AppleJuice/AppleJuice.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
 
-let appVersion = "3.0.5"
+let appVersion = "3.0.6"
 
 @main
 struct AppleJuice: ParsableCommand {

--- a/Sources/AppleJuice/Daemon/MaintainLoop.swift
+++ b/Sources/AppleJuice/Daemon/MaintainLoop.swift
@@ -218,6 +218,11 @@ final class MaintainDaemon {
                         }
                         sleepDuration = 60
                     case .enableCharging:
+                        // During sleep, don't re-enable charging. The willSleep
+                        // handler already decided the correct state. Re-enabling
+                        // here overrides willSleep's "charging disabled" decision
+                        // and causes uncontrolled charging during DarkWake.
+                        if self.isSleeping { return }
                         log("Charge below \(lowerLimit)")
                         controller.enableCharging()
                         let stillDisabled = getSMCChargingStatus(using: smcClient, caps: caps) == "disabled"


### PR DESCRIPTION
## Motivation

Woke up to 71% battery despite longevity targeting 60-65%. The willSleep handler correctly disabled charging at 37% (no AC connected), but the main loop's next iteration ran 4 seconds later, saw "37% < 60%", and re-enabled charging. The battery then charged from 37% to 65% during sleep. This pattern repeated across multiple sleep cycles, accumulating charge above target.

## Summary

- The main loop's `.enableCharging` path now checks `isSleeping` and returns early, preserving willSleep's decision
- The `.disableCharging` path still runs during sleep (needed for scheduled-wake cutoff at 65%)

Generated with [Claude Code](https://claude.com/claude-code)