### PR TITLE
feat: raise longevity to 70-75% and fix maintain input handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,3 +137,10 @@ Safety watchdog fix and CLI cleanup. **Breaking**: six commands removed (see bel
 ## v3.0.6
 
 - Main loop no longer re-enables charging when `isSleeping` is true -- the willSleep handler intentionally disabled charging, but the main loop's next iteration saw "battery below 60%" and overrode it, causing uncontrolled charging during sleep
+
+## v3.1.0
+
+- Longevity mode now maintains 70-75% instead of 60-65% -- the higher range leaves enough charge for a day of unplugged work while still avoiding the high-voltage stress near full charge
+- `maintain` validates its argument before stopping the running daemon -- previously a typo like `maintain 75-70` killed the daemon and left charging disabled until a safety check noticed
+- `maintain 75-70` is now accepted as shorthand for `maintain 75 70` (maintain level plus recharge threshold), the error message explains the recharge threshold forms, and an invalid threshold is rejected instead of silently ignored
+- `maintain <level>` and `maintain stop` show the battery status again -- the status output was captured by the subprocess runner and discarded, so both commands succeeded silently

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Three commands. Set it and forget it. Configure [macOS settings](#-setup) for no
 
 | What it does | Why it matters |
 |:---|:---|
-| Maintains charge between **60-65%** | Sweet spot for lithium-ion longevity |
+| Maintains charge between **70-75%** | Balances lithium-ion longevity with a useful day's charge |
 | Runs on wall power when plugged in | Battery sits idle at low voltage, minimal degradation |
 | **Cell imbalance monitoring** | Shows per-cell voltages and imbalance in `status` |
 | **BMS balancing** | Charges to 100% and holds for equalization when cells drift |
@@ -66,7 +66,7 @@ Three commands. Set it and forget it. Configure [macOS settings](#-setup) for no
 
 <br>
 
-> Lithium-ion cells degrade faster at higher voltages. At 100% charge each cell sits at ~4.2V, accelerating chemical wear. At 60-65% the resting voltage drops to ~3.95V/cell, significantly reducing stress. Once the battery reaches 65%, charging is disabled. The laptop then runs entirely from wall power — no current flows through the battery at all. Charging re-enables if the battery drops below 60%.
+> Lithium-ion cells degrade faster at higher voltages. At 100% charge each cell sits at ~4.2V, accelerating chemical wear. At 70-75% the resting voltage drops to ~4.0V/cell, significantly reducing stress while leaving enough charge for a day of unplugged work. Once the battery reaches 75%, charging is disabled. The laptop then runs entirely from wall power — no current flows through the battery at all. Charging re-enables if the battery drops below 70%.
 
 <br>
 
@@ -113,9 +113,9 @@ apple-juice maintain 80 50        # maintain 50-80%
 
 | Command | Description |
 |:---|:---|
-| `apple-juice maintain longevity` | **Recommended.** Maintain 60-65% for max lifespan |
+| `apple-juice maintain longevity` | **Recommended.** Maintain 70-75% for max lifespan |
 | `apple-juice maintain 80` | Maintain 75-80% |
-| `apple-juice maintain 80 50` | Maintain 50-80% |
+| `apple-juice maintain 80 50` | Maintain 50-80% (`80-50` also works) |
 | `apple-juice maintain suspend` | Temporarily charge to 100% |
 | `apple-juice maintain recover` | Resume after suspend |
 | `apple-juice maintain stop` | Disable completely |

--- a/Sources/AppleJuice/AppleJuice.swift
+++ b/Sources/AppleJuice/AppleJuice.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
 
-let appVersion = "3.0.6"
+let appVersion = "3.1.0"
 
 @main
 struct AppleJuice: ParsableCommand {
@@ -65,13 +65,9 @@ extension StartupAware {
 
 enum Paths {
     static let binfolder: String = {
-        // Resolve the binary location without dereferencing package-manager symlinks.
-        // When invoked as a bare name (e.g. "apple-juice" via PATH), arguments[0]
-        // has no directory component. Use /usr/bin/which to resolve PATH lookups.
-        // Important: do NOT resolve symlinks for the `which` result — Homebrew's
-        // /opt/homebrew/bin/apple-juice symlink is the stable path that survives
-        // upgrades. Resolving it yields a version-specific Cellar path that breaks
-        // every time the formula is upgraded.
+        // Bare invocations (via PATH) have no directory in arguments[0], so resolve
+        // with /usr/bin/which. Never resolve that result's symlinks: Homebrew's stable
+        // bin symlink would become a version-specific Cellar path that breaks on upgrade.
         let arg0 = CommandLine.arguments[0]
         let executableURL: URL
         if arg0.contains("/") {

--- a/Sources/AppleJuice/Commands/Maintain.swift
+++ b/Sources/AppleJuice/Commands/Maintain.swift
@@ -7,7 +7,7 @@ struct Maintain: ParsableCommand {
         abstract: "Maintain battery at a target percentage"
     )
 
-    @Argument(help: "Target percentage (10-100), or: stop, suspend, recover, longevity")
+    @Argument(help: "Target percentage (10-100), a range like 75-70, or: stop, suspend, recover, longevity")
     var target: String
 
     @Argument(help: "Lower bound percentage (recharge threshold)")
@@ -96,6 +96,34 @@ struct Maintain: ParsableCommand {
             return
         }
 
+        // Parse and validate the target before stopping the running daemon: an
+        // invalid argument must leave the current session untouched, not kill
+        // the daemon and leave charging disabled until a safety check notices.
+        var setting = target
+        var sub = lowerBound
+
+        if target != "stop" && target != "longevity" {
+            // Accept "75-70" as shorthand for "75 70"
+            if sub == nil, setting.contains("-") {
+                let parts = setting.split(separator: "-")
+                if parts.count == 2 {
+                    setting = String(parts[0])
+                    sub = String(parts[1])
+                }
+            }
+
+            guard let upper = Int(setting), upper >= 10, upper <= 100 else {
+                log("Error: \(target) is not a valid setting for maintain. Use a number between 10 and 100, optionally with a recharge threshold ('75 70' or '75-70'), 'longevity' for optimal lifespan, or 'stop'/'recover'.")
+                throw ExitCode.failure
+            }
+            if let sub {
+                guard let lower = Int(sub), lower >= 0, lower < upper else {
+                    log("Error: \(sub) is not a valid recharge threshold. Use a number below the maintain level \(upper).")
+                    throw ExitCode.failure
+                }
+            }
+        }
+
         // Kill old process
         if let pid {
             if kill(pid, 0) == 0 {
@@ -132,9 +160,6 @@ struct Maintain: ParsableCommand {
         }
 
         // Handle longevity preset
-        var setting = target
-        var sub = lowerBound
-
         let config = ConfigStore()
         if target == "longevity" {
             log("Longevity mode: maintaining 60-65% (optimal for battery lifespan)")
@@ -168,9 +193,9 @@ struct Maintain: ParsableCommand {
             try? config.write("longevity_mode", value: nil)
         }
 
-        // Validate percentage
-        guard let pct = Int(setting), pct >= 10, pct <= 100 else {
-            log("Error: \(setting) is not a valid setting for maintain. Please use a number between 10 and 100, 'longevity' for optimal lifespan, or 'stop'/'recover'.")
+        // Backstop only: setting was validated above or set by the longevity preset
+        guard let pct = Int(setting) else {
+            log("Error: \(setting) is not a valid setting for maintain")
             throw ExitCode.failure
         }
 

--- a/Sources/AppleJuice/Commands/Maintain.swift
+++ b/Sources/AppleJuice/Commands/Maintain.swift
@@ -1,6 +1,13 @@
 import ArgumentParser
 import Foundation
 
+/// Bounds used by longevity mode, shared with the status display.
+enum LongevityPreset {
+    static let upper = 75
+    static let lower = 70
+    static var range: String { "\(lower)-\(upper)%" }
+}
+
 struct Maintain: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "maintain",
@@ -163,9 +170,9 @@ struct Maintain: ParsableCommand {
         // Handle longevity preset
         let config = ConfigStore()
         if target == "longevity" {
-            log("Longevity mode: maintaining 60-65% (optimal for battery lifespan)")
-            setting = "65"
-            sub = "60"
+            log("Longevity mode: maintaining \(LongevityPreset.range) (optimal for battery lifespan)")
+            setting = String(LongevityPreset.upper)
+            sub = String(LongevityPreset.lower)
             try? config.write("longevity_mode", value: "enabled")
 
             // Auto-enable monthly balance

--- a/Sources/AppleJuice/Commands/Maintain.swift
+++ b/Sources/AppleJuice/Commands/Maintain.swift
@@ -146,7 +146,8 @@ struct Maintain: ParsableCommand {
             let smcClient = SMCBinaryClient()
             let caps = SMCCapabilities.probe(using: smcClient)
             ChargingController(client: smcClient, caps: caps).enableCharging()
-            ProcessRunner.run(binaryPath, arguments: ["status"])
+            let status = ProcessRunner.run(binaryPath, arguments: ["status"])
+            print(status.stdout, terminator: "")
             return
         }
 
@@ -211,7 +212,8 @@ struct Maintain: ParsableCommand {
         DaemonManager.startDaemon()
 
         // Report status
-        ProcessRunner.run(binaryPath, arguments: ["status"])
+        let status = ProcessRunner.run(binaryPath, arguments: ["status"])
+        print(status.stdout, terminator: "")
 
         // Ask about discharge if battery is above target
         let smcClient = SMCBinaryClient()

--- a/Sources/AppleJuice/Commands/Status.swift
+++ b/Sources/AppleJuice/Commands/Status.swift
@@ -126,7 +126,7 @@ struct Status: ParsableCommand {
 
             if maintainStatus == "active" {
                 if longevityConfigured {
-                    modeDescription = "longevity, maintaining 60-65%"
+                    modeDescription = "longevity, maintaining \(LongevityPreset.range)"
                 } else if let mp = maintainPercentage {
                     let parts = mp.split(separator: " ")
                     if let upperStr = parts.first, let upper = Int(upperStr) {


### PR DESCRIPTION
This PR raises longevity mode to maintain 70-75% instead of 60-65%, and fixes how the maintain command handles its argument. The longevity change trades a little voltage headroom for a working day of unplugged charge: at 60-65% a day away from the charger meant running out or dropping screen brightness, while 70-75% keeps resting cell voltage near 4.0V, still well below the ~4.2V of a full charge.

The maintain fixes come from a real session on v3.0.6. Typing `maintain 75-70` (an easy guess at range syntax) killed the running daemon before the argument was validated, then failed, leaving charging disabled with no daemon until a safety check noticed up to 30 minutes later. With this PR:

- The argument is validated before the running daemon is touched, so invalid input leaves the current session running.
- `75-70` is accepted as shorthand for `maintain 75 70` (maintain level plus recharge threshold), and an invalid threshold is rejected with a message explaining both forms.
- Starting or stopping maintain prints the battery status again; the output was being captured by the subprocess runner and discarded, so both commands succeeded silently.

Version bumped to 3.1.0 with a changelog entry.