### PR TITLE
fix: stop silent subcommand failures and a daemon-killing race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,3 +144,10 @@ Safety watchdog fix and CLI cleanup. **Breaking**: six commands removed (see bel
 - `maintain` validates its argument before stopping the running daemon -- previously a typo like `maintain 75-70` killed the daemon and left charging disabled until a safety check noticed
 - `maintain 75-70` is now accepted as shorthand for `maintain 75 70` (maintain level plus recharge threshold), the error message explains the recharge threshold forms, and an invalid threshold is rejected instead of silently ignored
 - `maintain <level>` and `maintain stop` show the battery status again -- the status output was captured by the subprocess runner and discarded, so both commands succeeded silently
+
+## v3.1.1
+
+- Subcommands launched internally (the status report after `maintain`, discharge operations, `maintain recover`) now resolve the binary's real path first -- when apple-juice was invoked by bare name from PATH, those launches silently failed because Foundation's Process does no PATH lookup, which is why `maintain` still printed nothing in v3.1.0
+- Failed subprocess launches are now logged instead of silently returning empty output
+- The safety watchdog no longer kills a maintain daemon that is mid-startup: the daemon writes its PID file before its multi-second SMC startup work, safety checks look for a live daemon process before restarting anything, and the watchdog agent is no longer re-bootstrapped (firing its RunAtLoad check at the worst moment) on every maintain run
+- README "How It Works" section updated to the 70-75% longevity range introduced in v3.1.0

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ SMC access is granted through visudo with specific command allowlists — only t
 
 apple-juice runs as a background daemon managed by macOS `launchd`. It reads battery state through IOKit and controls charging via SMC keys using the bundled `smc` binary.
 
-When the battery reaches the upper limit (65% in longevity mode), charging is disabled via SMC. The laptop continues to run entirely from wall power — the battery sits idle at its resting voltage with no current flowing. Charging only re-enables when the battery drops below the lower limit (60%), which only happens if you unplug.
+When the battery reaches the upper limit (75% in longevity mode), charging is disabled via SMC. The laptop continues to run entirely from wall power — the battery sits idle at its resting voltage with no current flowing. Charging only re-enables when the battery drops below the lower limit (70%), which only happens if you unplug.
 
 The daemon is configured as a LaunchAgent with `KeepAlive`, so macOS automatically restarts it if the process dies unexpectedly. On clean shutdown (`maintain stop`), it re-enables charging and stays stopped. A startup recovery check runs before every command: if charging is found disabled but the daemon is not running, charging is re-enabled automatically. This ensures a Mac is never left in a non-charging state.
 

--- a/Sources/AppleJuice/AppleJuice.swift
+++ b/Sources/AppleJuice/AppleJuice.swift
@@ -89,6 +89,20 @@ enum Paths {
         return "/usr/local/co.apple-juice"
     }()
 
+    /// Absolute path to this binary, for launching apple-juice subcommands.
+    /// argv[0] is a bare name when invoked via PATH, and Foundation's Process
+    /// does no PATH lookup, so launching a bare name silently fails.
+    static let selfBinary: String = resolveSelfBinary(from: CommandLine.arguments[0])
+
+    static func resolveSelfBinary(from arg0: String) -> String {
+        if arg0.contains("/") {
+            return URL(fileURLWithPath: arg0).standardizedFileURL.path
+        }
+        let result = ProcessRunner.run("/usr/bin/which", arguments: [arg0])
+        let resolved = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return resolved.isEmpty ? arg0 : resolved
+    }
+
     static let configFolder = (NSHomeDirectory() as NSString).appendingPathComponent(".apple-juice")
     static let pidFile = (configFolder as NSString).appendingPathComponent("apple-juice.pid")
     static let logFile = (configFolder as NSString).appendingPathComponent("apple-juice.log")

--- a/Sources/AppleJuice/AppleJuice.swift
+++ b/Sources/AppleJuice/AppleJuice.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
 
-let appVersion = "3.1.0"
+let appVersion = "3.1.1"
 
 @main
 struct AppleJuice: ParsableCommand {

--- a/Sources/AppleJuice/Commands/Balance.swift
+++ b/Sources/AppleJuice/Commands/Balance.swift
@@ -8,7 +8,7 @@ struct Balance: ParsableCommand {
     )
 
     func run() throws {
-        let binaryPath = CommandLine.arguments[0]
+        let binaryPath = Paths.selfBinary
         try "\(getpid())".write(toFile: Paths.calibratePidFile, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(atPath: Paths.calibratePidFile) }
 

--- a/Sources/AppleJuice/Commands/Calibrate.swift
+++ b/Sources/AppleJuice/Commands/Calibrate.swift
@@ -11,7 +11,7 @@ struct Calibrate: ParsableCommand {
     var action: String?
 
     func run() throws {
-        let binaryPath = CommandLine.arguments[0]
+        let binaryPath = Paths.selfBinary
         let config = ConfigStore()
 
         // Check if this is a scheduled (non-terminal) invocation

--- a/Sources/AppleJuice/Commands/Charge.swift
+++ b/Sources/AppleJuice/Commands/Charge.swift
@@ -29,7 +29,7 @@ struct Charge: ParsableCommand {
 
         // Save and suspend maintain
         let originalMaintainStatus = ProcessHelper.readPidFileStatus(Paths.pidFile)
-        let binaryPath = CommandLine.arguments[0]
+        let binaryPath = Paths.selfBinary
         ProcessRunner.run(binaryPath, arguments: ["maintain", "suspend"])
 
         // Write state file for orphan detection
@@ -155,7 +155,7 @@ struct Discharge: ParsableCommand {
 
         // Save and suspend maintain
         let originalMaintainStatus = ProcessHelper.readPidFileStatus(Paths.pidFile)
-        let binaryPath = CommandLine.arguments[0]
+        let binaryPath = Paths.selfBinary
         ProcessRunner.run(binaryPath, arguments: ["maintain", "suspend"])
 
         // Write state file for orphan detection

--- a/Sources/AppleJuice/Commands/Maintain.swift
+++ b/Sources/AppleJuice/Commands/Maintain.swift
@@ -24,7 +24,7 @@ struct Maintain: ParsableCommand {
     var forceDischarge = false
 
     func run() throws {
-        let binaryPath = CommandLine.arguments[0]
+        let binaryPath = Paths.selfBinary
 
         // Determine if called by another apple-juice process (suppresses notifications)
         let ppid = getppid()
@@ -299,7 +299,7 @@ struct MaintainDaemonCommand: ParsableCommand {
                 throw ExitCode.failure
             }
             log("Triggering discharge to \(upper) before enabling charging limiter")
-            let binaryPath = CommandLine.arguments[0]
+            let binaryPath = Paths.selfBinary
             ProcessRunner.run(binaryPath, arguments: ["discharge", String(upper)])
             log("Discharge pre maintenance complete, continuing to maintenance loop")
         }

--- a/Sources/AppleJuice/Commands/SafetyCheck.swift
+++ b/Sources/AppleJuice/Commands/SafetyCheck.swift
@@ -16,19 +16,16 @@ struct SafetyCheck: ParsableCommand {
         recoverOrphanedChargeState()
 
         if ProcessHelper.maintainIsRunning() {
-            // The sleep.state file is created by the daemon in willSleep and
-            // deleted in didWake. It persists on disk across daemon restarts,
-            // so even if the watchdog kills and KeepAlive restarts the daemon
-            // during DarkWake (Power Nap, scheduled wakes), the file remains
-            // and prevents further false kills.
+            // sleep.state is written in willSleep, deleted in didWake, and
+            // survives daemon restarts, so DarkWake watchdog kill/restart
+            // cycles still see it and stop killing the daemon again.
             if FileManager.default.fileExists(atPath: Paths.sleepStateFile) {
                 return
             }
 
-            // Daemon process is alive. Check for a hung loop by comparing PID
-            // file staleness against system uptime (not wall clock). System
-            // uptime doesn't advance during sleep, so the PID file won't
-            // appear stale just because the Mac was asleep.
+            // Daemon is alive. Detect a hung loop via PID file staleness
+            // measured against system uptime, which doesn't advance during
+            // sleep, so a sleeping Mac doesn't make the file look stale.
             if let attrs = try? FileManager.default.attributesOfItem(atPath: Paths.pidFile),
                let modified = attrs[.modificationDate] as? Date {
                 let wallElapsed = Date().timeIntervalSince(modified)
@@ -41,6 +38,14 @@ struct SafetyCheck: ParsableCommand {
                     }
                 }
             }
+            return
+        }
+
+        // The PID file says no daemon, but one may be mid-startup and simply
+        // not have written its PID file yet. Restarting here would bootout
+        // the healthy daemon.
+        if ProcessHelper.maintainDaemonProcessExists() {
+            log("Safety watchdog: daemon process is starting up, skipping check.")
             return
         }
 

--- a/Sources/AppleJuice/Commands/SafetyCheck.swift
+++ b/Sources/AppleJuice/Commands/SafetyCheck.swift
@@ -97,7 +97,7 @@ func recoverOrphanedChargeState() {
 
         // Recover maintain if it was active before the orphaned operation
         if parts.count >= 3 && parts[2] == "active" {
-            let binaryPath = CommandLine.arguments[0]
+            let binaryPath = Paths.selfBinary
             ProcessRunner.run(binaryPath, arguments: ["maintain", "recover"])
         }
     }

--- a/Sources/AppleJuice/Commands/Status.swift
+++ b/Sources/AppleJuice/Commands/Status.swift
@@ -224,6 +224,15 @@ enum ProcessHelper {
         isProcessRunning(pidFile: Paths.calibratePidFile)
     }
 
+    /// Check the process table for a live maintain daemon, regardless of PID
+    /// file state. A freshly bootstrapped daemon does seconds of SMC startup
+    /// work before writing its PID file; PID-file checks alone call it dead.
+    static func maintainDaemonProcessExists() -> Bool {
+        let result = ProcessRunner.run(
+            "/usr/bin/pgrep", arguments: ["-f", "apple-juice maintain-daemon"])
+        return !result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     /// Read the status field from a PID file (format: "PID STATUS").
     static func readPidFileStatus(_ path: String) -> String? {
         guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return nil }

--- a/Sources/AppleJuice/Config/Migration.swift
+++ b/Sources/AppleJuice/Config/Migration.swift
@@ -111,6 +111,10 @@ enum Migration {
 
         guard !ProcessHelper.maintainIsRunning() else { return }
 
+        // A daemon mid-startup has not written its PID file yet; restarting
+        // it here would kill it. Leave it to finish coming up.
+        guard !ProcessHelper.maintainDaemonProcessExists() else { return }
+
         let smcClient = SMCBinaryClient()
         let caps = SMCCapabilities.probe(using: smcClient)
         let chargingStatus = getSMCChargingStatus(using: smcClient, caps: caps)

--- a/Sources/AppleJuice/Daemon/DaemonManager.swift
+++ b/Sources/AppleJuice/Daemon/DaemonManager.swift
@@ -161,8 +161,16 @@ enum DaemonManager {
             try? plist.write(toFile: path, atomically: true, encoding: .utf8)
         }
 
-        // Always run launchctl calls -- the plist being on disk doesn't mean
-        // the service is loaded in launchd.
+        // Reload only when the plist changed or the service is not loaded in
+        // launchd. Re-bootstrapping on every maintain run fires RunAtLoad, and
+        // that safety check races the maintain daemon's own startup.
+        let loaded = ProcessRunner.shell(
+            "launchctl print gui/\(uid)/com.apple-juice.safety", timeout: 10
+        ).succeeded
+        if !needsWrite && loaded {
+            return
+        }
+
         launchctl("launchctl enable gui/\(uid)/com.apple-juice.safety")
         launchctl("launchctl bootout gui/\(uid)/com.apple-juice.safety", silent: true)
         Thread.sleep(forTimeInterval: 0.5)

--- a/Sources/AppleJuice/Daemon/MaintainLoop.swift
+++ b/Sources/AppleJuice/Daemon/MaintainLoop.swift
@@ -479,7 +479,7 @@ final class MaintainDaemon {
         if imbalance > 200 {
             let voltages = battery.cellVoltages?.map(String.init).joined(separator: ", ") ?? "?"
             log("Cell imbalance detected: \(imbalance)mV (cells: \(voltages)mV). Triggering balance for BMS cell balancing.")
-            let binaryPath = CommandLine.arguments[0]
+            let binaryPath = Paths.selfBinary
             let process = Process()
             process.executableURL = URL(fileURLWithPath: binaryPath)
             process.arguments = ["balance"]

--- a/Sources/AppleJuice/Daemon/MaintainLoop.swift
+++ b/Sources/AppleJuice/Daemon/MaintainLoop.swift
@@ -31,10 +31,9 @@ final class MaintainDaemon {
     // All mutable state below is accessed from multiple threads (main loop,
     // sleep/wake callback, signal handler) and MUST be read/written under smcQueue.
     private var status: Status = .active
-    /// True between willSleep and didWake. During DarkWake (Power Nap,
-    /// scheduled wakes) the main loop gets CPU time but no IOKit wake
-    /// notification fires, so this flag stays true and writePidFile()
-    /// writes "sleeping" instead of the actual status.
+    /// True between willSleep and didWake. During DarkWake the main loop
+    /// gets CPU time but no IOKit wake notification fires, so this stays
+    /// true and writePidFile() writes "sleeping" instead of the status.
     private var isSleeping = false
     private var upperLimit: Int
     private var lowerLimit: Int
@@ -71,17 +70,25 @@ final class MaintainDaemon {
     }
 
     func run() {
+        // Adopt DarkWake sleeping state before the first PID write, which
+        // deletes sleep.state whenever the daemon is not sleeping.
+        if FileManager.default.fileExists(atPath: Paths.sleepStateFile) {
+            isSleeping = true
+        }
+
+        // Publish the PID before any SMC work: safety checks read the PID
+        // file, and the SMC startup below takes seconds, leaving a window
+        // where a concurrent check sees a dead daemon and restarts us.
+        writePidFile()
+
         // Reset CHWA
         if caps.hasCHWA {
             smcClient.write(.CHWA, value: SMCWriteValue.CHWA_disable)
         }
 
-        // Apply charging control immediately on startup rather than waiting
-        // for the first loop iteration. This avoids a brief window where
-        // charging is enabled despite the battery being above the target.
-        // If the read returns 0, the SMC is unresponsive (common during
-        // DarkWake) -- disable charging as a safe default rather than
-        // enabling it based on a bogus 0% reading.
+        // Apply charging control now, not on the first loop iteration, to
+        // avoid a window of charging above target. A 0 reading means the SMC
+        // is unresponsive (DarkWake): disable charging as the safe default.
         let startPct = getBatteryPercentage(using: smcClient)
         if startPct <= 0 || startPct >= upperLimit {
             controller.disableCharging()
@@ -150,11 +157,9 @@ final class MaintainDaemon {
                     }
                 case .didWake:
                     self.isSleeping = false
-                    // sleep.state is deleted by writePidFile() after the PID
-                    // file is updated, not here. This avoids a race where
-                    // the watchdog fires at the same moment as didWake, sees
-                    // no sleep.state, and kills the daemon before the main
-                    // loop has updated the PID file.
+                    // sleep.state deletion happens in writePidFile() after the
+                    // PID update; deleting it here would let a didWake-moment
+                    // watchdog see no sleep.state and kill the daemon.
                     WakeScheduler.cancelWake()
                     if self.caps.hasCHWA {
                         self.smcClient.write(.CHWA, value: SMCWriteValue.CHWA_disable)
@@ -218,10 +223,9 @@ final class MaintainDaemon {
                         }
                         sleepDuration = 60
                     case .enableCharging:
-                        // During sleep, don't re-enable charging. The willSleep
-                        // handler already decided the correct state. Re-enabling
-                        // here overrides willSleep's "charging disabled" decision
-                        // and causes uncontrolled charging during DarkWake.
+                        // Don't re-enable charging during sleep: willSleep
+                        // already chose the state, and overriding it causes
+                        // uncontrolled charging during DarkWake.
                         if self.isSleeping { return }
                         log("Charge below \(lowerLimit)")
                         controller.enableCharging()
@@ -368,10 +372,9 @@ final class MaintainDaemon {
         exit(0)
     }
 
-    /// Fatal exit: clean up and exit 1 for launchd restart.
-    /// During DarkWake, SMC writes are unreliable and the restarted daemon
-    /// will disable charging on startup, so skip enableCharging and preserve
-    /// sleep.state to prevent the watchdog from killing the replacement.
+    /// Fatal exit: clean up and exit 1 for launchd restart. During DarkWake
+    /// SMC writes are unreliable, so skip enableCharging and keep sleep.state
+    /// so the watchdog doesn't kill the replacement daemon.
     private func fatalExit() {
         sleepWakeListener?.stop()
         WakeScheduler.cancelWake()

--- a/Sources/AppleJuice/Utilities/ProcessRunner.swift
+++ b/Sources/AppleJuice/Utilities/ProcessRunner.swift
@@ -34,6 +34,7 @@ enum ProcessRunner {
         do {
             try process.run()
         } catch {
+            log("Error: failed to launch \(executable): \(error.localizedDescription)")
             return ProcessResult(exitCode: -1, stdout: "", stderr: error.localizedDescription)
         }
 

--- a/Tests/AppleJuiceTests/SelfBinaryTests.swift
+++ b/Tests/AppleJuiceTests/SelfBinaryTests.swift
@@ -1,0 +1,29 @@
+import Testing
+import Foundation
+@testable import apple_juice
+
+@Suite("Self Binary Resolution Tests")
+struct SelfBinaryTests {
+    @Test func absolutePathIsKeptAsIs() {
+        #expect(Paths.resolveSelfBinary(from: "/usr/bin/true") == "/usr/bin/true")
+    }
+
+    @Test func relativePathWithSlashIsAnchoredToCwd() {
+        let resolved = Paths.resolveSelfBinary(from: "./some/dir/apple-juice")
+        let cwd = FileManager.default.currentDirectoryPath
+        #expect(resolved == "\(cwd)/some/dir/apple-juice")
+    }
+
+    @Test func bareNameIsResolvedThroughPath() {
+        // Foundation's Process does no PATH lookup, so a bare argv[0] must
+        // come back as an absolute path for self-invocations to launch.
+        let resolved = Paths.resolveSelfBinary(from: "sh")
+        #expect(resolved.hasPrefix("/"))
+        #expect(FileManager.default.isExecutableFile(atPath: resolved))
+    }
+
+    @Test func unresolvableBareNameFallsBackToInput() {
+        let resolved = Paths.resolveSelfBinary(from: "definitely-not-a-real-binary-xyz")
+        #expect(resolved == "definitely-not-a-real-binary-xyz")
+    }
+}


### PR DESCRIPTION
This PR fixes 2 problems found while verifying the v3.1.0 release on a live machine, plus a README correction.

First, commands that launch other apple-juice subcommands internally (the status report after `maintain`, discharge operations, recovery) passed argv[0] to Foundation's Process, which does no PATH lookup. When the tool is invoked the normal way, as a bare `apple-juice` from PATH, argv[0] is just that bare word, so every internal launch failed and the failure was invisible. This is why `maintain` still finished silently in v3.1.0 despite that release claiming to restore the status output: the fix was only ever exercised with a path-qualified binary. Internal launches now resolve the binary's real path first (unit tested), and any failed launch is logged instead of returning empty output silently.

Second, the safety watchdog could kill a healthy daemon. Safety checks judge the daemon dead by reading its PID file, but a freshly started daemon spends several seconds on SMC setup before writing that file. Worse, every maintain run re-bootstrapped the watchdog agent, whose RunAtLoad setting fired a check at exactly that moment; today that killed the new daemon twice in a row, leaving charging disabled until a later check recovered it. Now the daemon writes its PID file before SMC work, safety checks also look for a live daemon process before restarting anything, and the watchdog agent is only re-bootstrapped when its plist changed or it is not loaded.

The README's how-it-works section is also corrected to the 70-75% longevity range introduced in v3.1.0, and the version is bumped to 3.1.1 with a changelog entry.