### PR TITLE
chore: cancel superseded CI runs when a branch is re-pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# A re-push to the same branch makes the previous run's result obsolete, so cancel
+# it instead of letting it finish and hold a runner slot.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: macos-15


### PR DESCRIPTION
This PR puts the CI workflow in a concurrency group keyed on workflow and branch with cancel-in-progress enabled, so pushing new commits to a branch cancels the still-running checks from the previous push instead of letting an obsolete run finish and delay the fresh one. The tag-triggered release workflow is left untouched, so a release build is never cancelled mid-run.